### PR TITLE
deleting `test_add_profile_ok` after executing test body

### DIFF
--- a/tests/test_add_profile.py
+++ b/tests/test_add_profile.py
@@ -82,6 +82,9 @@ class TestAddProfile:
         assert msg.BUILD_REQUIRED in out
         assert not err
 
+        arguments = arg_parser.parse_args(["del", "test_add_profile_ok"])
+        executor.execute_command(arguments)
+
     def test_add_profile_quiet(self, capsys, monkeypatch):
         arg_parser = parser.get_arguments_parser()
         arguments = arg_parser.parse_args(["-q", "add", "test_add_profile_ok"])


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_add_profile_no_param` by deleting `test_add_profile_ok` after executing test body by calling method `executor.execute_command` with corresponding arguments.

The test can fail in this way if `test_add_profile_ok` is not deleted:
```
        out, err = capsys.readouterr()
>       assert msg.BUILD_REQUIRED in out
E       AssertionError: assert 'This parameter is required!' in '[ERROR] The profile test_add_profile_ok exists. Did you mean -u/--update?\n'
E        +  where 'This parameter is required!' = msg.BUILD_REQUIRED
